### PR TITLE
Added the ability to close the HID device

### DIFF
--- a/blink1.js
+++ b/blink1.js
@@ -246,6 +246,10 @@ Blink1.prototype.readPatternLine = function(position, callback) {
   });
 };
 
+Blink1.prototype.close = function() {
+	this.hidDevice.close();
+};
+
 Blink1.devices = devices;
 
 module.exports = Blink1;


### PR DESCRIPTION
I've added the ability to close the HID device, because when using Node-RED it was breaking when deploying a change to something involving a Blink1.
