### PR TITLE
Update node-hid dependency to ~0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "blink1"
   ],
   "dependencies": {
-    "node-hid": "~0.3.2"
+    "node-hid": "~0.4.0"
   },
   "devDependencies": {
     "jshint": "latest",


### PR DESCRIPTION
Older versions of node-hid were failing to install on node v0.12.x, and that [has been corrected](https://github.com/node-hid/node-hid/issues/90). I've tested this myself, just to make sure node-blink1 worked with the newest version of node-hid, and it worked fine on node v0.12.2