### PR TITLE
added change to support issue #23 feature request for ledn support

### DIFF
--- a/blink1.js
+++ b/blink1.js
@@ -150,13 +150,16 @@ Blink1.prototype.degamma = function(n) {
 };
 
 
-Blink1.prototype.fadeToRGB = function(fadeMillis, r, g, b, callback) {
+Blink1.prototype.fadeToRGB = function(fadeMillis, r, g, b /*, callback or ledn, callback */ ) {
+  var ledn = (typeof arguments[4] === 'number') ? arguments[4] : 0;
+  var callback = (typeof arguments[4] === 'function') ? arguments[4] : (typeof arguments[5] === 'function') ? arguments[5] : null;
+
   this._validateFadeMillis(fadeMillis);
   this._validateRGB(r, g, b);
 
   var dms = fadeMillis / 10;
 
-  this._sendCommand('c', this.degamma(r), this.degamma(g), this.degamma(b), dms >> 8, dms % 0xff);
+  this._sendCommand('c', this.degamma(r), this.degamma(g), this.degamma(b), dms >> 8, dms % 0xff, ledn);
 
   if(this._isValidCallback(callback)) {
     setTimeout(callback, fadeMillis);


### PR DESCRIPTION
Hi,
I saw the issue #23 question by @chrisparnin to add `ledn` support.  Here is a pull-request with one way to do it.  I wasn't sure if doing optional arguments in this way was exactly correct, but I wanted to be backwards compatible without increasing API load.  I also only did this for `fadeToRGB`, but you all of these are valid:
```
blink1.fadeToRGB( 100, 255,0,0 ); // just like before
blink1.fadeToRGB( 100, 255,0,0, function() { console.log('hello') }  ); // just like before
blink1.fadeToRGB( 100, 0,255,0, 1 ); //  turn LED#1 green
blink1.fadeToRGB( 100, 0,0,255, 2 ); //  turn LED#2 blue
blink1.fadeToRGB( 100, 0,0,255, 0, function() { console.log("off") }  ); //  turn both off
```
