### PR TITLE
#28: High level pattern player API

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "blink1"
   ],
   "dependencies": {
-    "node-hid": "~0.5.0"
+    "node-hid": "~0.5.0",
+    "tinycolor2": "^1.4.1"
   },
   "devDependencies": {
     "jshint": "latest",

--- a/test-sequence.js
+++ b/test-sequence.js
@@ -1,0 +1,57 @@
+var async = require('async');
+
+var Blink1 = require('./blink1');
+
+var blink1 = new Blink1();
+
+async.series([
+  function(callback) {
+    console.log("repeat pattern");
+    var pattern = ["black", "blue", "blue", "green", "black", {color: "black", delay: 1000}];
+    blink1.repeatPattern(pattern, 3, function() {
+      callback();
+    });
+  },
+  function(callback) {
+    console.log('rgb pattern');
+    var pattern = [{r: 255, g: 0, b:0}, {r: 0, g: 0, b: 0, delay: 1000}, {r: 255, g: 255, b: 0}];
+    blink1.playPattern(pattern, function() {
+      callback();
+    });
+  },
+  function(callback) {
+    console.log('color pattern');
+    var pattern = [{color: "black", delay: 1000}, "red", {color: "white", delay: 1000}, "yellow"];
+    blink1.playPattern(pattern, function() {
+      callback();
+    });
+  },
+  function(callback) {
+    console.log('loop pattern');
+    var pattern = ["black", "red", "red", "black"];
+    blink1.loopPattern(pattern);
+    setTimeout(callback, 2000)
+  },
+  function(callback) {
+    console.log('change pattern');
+    var pattern = ["black", "orange", "orange", "black"];
+    blink1.loopPattern(pattern);
+    setTimeout(callback, 2000)
+  },
+  function(callback) {
+    console.log("stop");
+    blink1.stopPattern();
+    callback();
+  },
+  function(callback) {
+    console.log('off');
+    blink1.off(function() {
+      console.log('\tdone');
+
+      callback();
+    });
+  },
+  function() {
+    process.exit(0);
+  }
+]);


### PR DESCRIPTION
A first stab at #28.

Notes:
- I found it difficult to approach the timing logic in combination with `unit-tests.js`, so I only added a `test-sequence.js` "manual" test instead
- Supports tinycolor2 to use color names. Adds function `fadeToColor` which uses tinycolor
- Implemented using the setTimeout mechanism in `fadeToRGB`
- When I tried to implement using `writePatternLine` and `play`, more colors than those I had specified where displayed!
