### PR TITLE
Update library to use JS Promises instead of callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ See [node-hid's compiling from source instructions](https://github.com/node-hid/
 ## Usage
 
 ```javascript
-var Blink1 = require('node-blink1');
+const { Blink1, devices } = require('node-blink1');
 ```
 
 Get list of blink(1) devices connected:
 
 ```javascript
-Blink1.devices(); // returns array of serial numbers
+devices(); // returns array of serial numbers
 ```
 
 Create blink(1) object without serial number, uses first device:
@@ -37,7 +37,7 @@ var blink1 = new Blink1();
 ```
 
 Create blink(1) object with serial number, to get list of serial numbers use
-`Blink1.devices()`:
+`devices()`:
 
 ```javascript
 var blink1 = new Blink1(serialNumber);
@@ -45,91 +45,161 @@ var blink1 = new Blink1(serialNumber);
 
 ### Get version
 
+Returns Promise
+
 ```javascript
-blink1.version(callback(version));
+blink1.version().then*(version => {
+    // version
+});
 ```
 
 ### Set colors
 
-Fade to RGB, optional callback called after `fadeMillis` ms:
+Fade to RGB, returns Promise after `delay` ms:
 
 ```javascript
-blink1.fadeToRGB(fadeMillis, r, g, b, [callback]); // r, g, b: 0 - 255
-
-blink1.fadeToRGB(fadeMillis, r, g, b, [index, callback]); // r, g, b: 0 - 255
-                                                          // index (mk2 only): 0 - 2
+let blinkObject = {
+    delay : 1000, // Optional # or ms
+    red   : 128,  // Required 0 - 255
+    green : 128,  // Required 0 - 255
+    blue  : 128   // Required 0 - 255
+    index : 0     // Optionsl 0 - 2 (mk2 Only)
+};
+blink1.fadeToRGB(blinkObject);
 ```
 
-Set RGB:
+#### Extended Fade example
+
+Because most functions return promises, you can now chain actions together.
+
+This example will cause the device to fade to red over 2.5s, once complete, the device will then fade to green over another 2.5s.
 
 ```javascript
-blink1.setRGB(r, g, b, [callback]); // r, g, b: 0 - 255
+let blinkObject = {
+    delay : 2500,
+    red   : 255,
+    green : 0,
+    blue  : 0
+};
+blink1.fadeToRGB(blinkObject).then(({red, green, blue}) => {
+    let blinkObject = {
+        delay : 2500,
+        red   : 0,
+        green : 255,
+        blue  : 0
+    };
+    blink1.fadeToRGB(blinkObject);
+});
 ```
 
-Get RGB (mk2 only):
+Set RGB, returns Promise:
 
 ```javascript
-blink1.rgb([index,] callback(r, g, b));
+let blinkObject = {
+    red   : 128,  // Required 0 - 255
+    green : 128,  // Required 0 - 255
+    blue  : 128   // Required 0 - 255
+};
+blink1.setRGB(blinkObject);
 ```
 
-Off:
+Get RGB, returns Promise (mk2 only):
 
 ```javascript
-blink1.off([callback]);
+blink1.getRGB(index); // index defaults to 0
+```
+
+Off, returns Promise:
+
+```javascript
+blink1.off();
 ```
 
 ### Other methods
 
-Set server down (enable, disable), optional callback called after `millis` ms:
+Set server down (enable, disable), , returns Promise after `delay` ms:
 
 ```javascript
-blink1.enableServerDown(millis, [callback]); // tickle
+blink1.enableServerDown(delay); // tickle
 
-blink1.disableServerDown(millis, [callback]); // off
+blink1.disableServerDown(delay); // off
 ```
 
-Play (start playing the pattern lines at the specified position):
+Play (start playing the pattern lines at the specified position), returns Promise:
 
 ```javascript
-blink1.play(position, [callback]);
+blink1.play(position);
 ```
 
-Play Loop (start playing a subset of the pattern lines at specified start and end positions. Specifying count = 0 will loop pattern forever):
+Play Loop (start playing a subset of the pattern lines at specified start and end positions. Specifying count = 0 will loop pattern forever), returns Promise:
 
 ```javascript
-blink1.playLoop(startPosition, endPosition, count, [callback]);
+let blinkObject = {
+    start : 1, // Required
+    end   : 2, // Required
+    count : 2  // Required
+};
+blink1.playLoop(blinkObject);
 ```
 
-Pause (stop playing the pattern line):
+Pause (stop playing the pattern line), returns Promise:
 
 ```javascript
-blink1.pause([callback]);
+blink1.pause();
 ```
 
-Write pattern line (set the parameters for a pattern line, at the specified position):
+Write pattern line (set the parameters for a pattern line, at the specified position), returns Promise:
 
 ```javascript
-blink1.writePatternLine(fadeMillis, r, g, b, position, [callback]) // r, g, b: 0 - 255
+let blinkObject = {
+    delay    : 100, // Required # of ms
+    red      : 128, // Required 0 - 255
+    green    : 128, // Required 0 - 255
+    blue     : 128, // Required 0 - 255
+    position : 2    // Required
+};
+blink1.writePatternLine(blinkObject);
 ````
 
 A simple example of this, used to flash red on & off is:
 
 ```javascript
-blink1.writePatternLine(200, 255, 0, 0, 0);
-blink1.writePatternLine(200, 0, 0, 0, 1);
+let blinkObject = {
+    delay    : 200,
+    red      : 255,
+    green    : 0,
+    blue     : 0,
+    position : 0
+};
+let blinkObject2 = {
+    delay    : 200,
+    red      : 0,
+    green    : 0,
+    blue     : 0,
+    position : 1
+};
+blink1.writePatternLine(blinkObject);
+blink1.writePatternLine(blinkObject2);
 blink1.play(0);
 ```
 
-Read pattern line (at the position):
+Read pattern line (at the position), returns Promise:
 
 ```javascript
-blink1.readPatternLine(position, [callback])
+blink1.readPatternLine(position).then(({
+    red,
+    green,
+    blue,
+    delay
+}) => {
+    // readPatternLine values
+});
 ```
 
-Close (the underlying HID device):
+Close (the underlying HID device), returns Promise:
 
 ```javascript
-blink1.close([callback]);
+blink1.close();
 ```
 
 ## License

--- a/blink1.js
+++ b/blink1.js
@@ -221,14 +221,7 @@ class Blink1 {
                 this._validateRGB(red, green, blue);
                 this._validateIndex(index);
             } catch(error) {
-                reject(JSON.stringify({
-                    error,
-                    delay,
-                    red,
-                    green,
-                    blue,
-                    index
-                }));
+                reject(error);
             }
 
             let dms = delay / 10;

--- a/blink1.js
+++ b/blink1.js
@@ -1,321 +1,422 @@
-var HID = require('node-hid');
+const HID = require('node-hid');
+const _   = require('lodash');
 
-var VENDOR_ID = 0x27B8;
-var PRODUCT_ID = 0x01ED;
+const VENDOR_ID  = 0x27B8;
+const PRODUCT_ID = 0x01ED;
 
-var REPORT_ID = 1;
-var REPORT_LENGTH = 9;
+const REPORT_ID     = 1;
+const REPORT_LENGTH = 9;
 
-var _blink1HIDdevices = function() {
-  return HID.devices(VENDOR_ID, PRODUCT_ID);
+let _blink1HIDdevices = () => {
+    return HID.devices(VENDOR_ID, PRODUCT_ID);
 };
 
-var devices = function() {
-  var serialNumbers = [];
-
-  _blink1HIDdevices().forEach(function(device) {
-    serialNumbers.push(device.serialNumber);
-  });
-
-  return serialNumbers;
+let devices = () => {
+    return _.map(_blink1HIDdevices(), ({ serialNumber }) => serialNumber);
 };
 
-function Blink1(serialNumber) {
-  var blink1HIDdevices = _blink1HIDdevices();
+class Blink1 {
+    constructor(serialNumber) {
+        let blink1HIDdevices = _blink1HIDdevices();
 
-  if (blink1HIDdevices.length === 0) {
-    throw new Error('No blink(1)\'s could be found');
-  }
+        if (blink1HIDdevices.length === 0) {
+            throw new Error('No blink(1)\'s could be found');
+        }
 
-  var blink1HIDdevicePath = null;
+        var blink1HIDdevicePath = null;
 
-  if (serialNumber === undefined) {
-    serialNumber =  blink1HIDdevices[0].serialNumber;
-  }
+        if (serialNumber === undefined) {
+            serialNumber = blink1HIDdevices[0].serialNumber;
+        }
 
-  blink1HIDdevices.some(function(blink1HIDdevice) {
-    if (serialNumber === blink1HIDdevice.serialNumber) {
-      blink1HIDdevicePath = blink1HIDdevice.path;
+        _.find(blink1HIDdevices, (blink1HIDdevice) => {
+            if (serialNumber === blink1HIDdevice.serialNumber) {
+                blink1HIDdevicePath = blink1HIDdevice.path;
+            }
+
+            return (blink1HIDdevicePath !== null);
+        });
+
+        if (blink1HIDdevicePath === null) {
+            throw new Error('No blink(1)\'s with serial number ' + serialNumber + ' could be found');
+        }
+
+        this.serialNumber = serialNumber;
+        this.hidDevice = new HID.HID(blink1HIDdevicePath);
+
+        this.doDegamma = true;
     }
 
-    return (blink1HIDdevicePath !== null);
-  });
+    // Hardware API
 
-  if (blink1HIDdevicePath === null) {
-    throw new Error('No blink(1)\'s with serial number ' + serialNumber + ' could be found');
-  }
+    _sendCommand(/* command [, args ...]*/) {
+        var featureReport = [REPORT_ID, 0, 0, 0, 0, 0, 0, 0, 0];
 
-  this.serialNumber = serialNumber;
-  this.hidDevice = new HID.HID(blink1HIDdevicePath);
+        _.forEach(arguments, (argument, k) => {
+            if (k === 0) {
+                featureReport[1] = argument.charCodeAt(0);
+                return;
+            }
+
+            featureReport[k + 1] = argument;
+        });
+
+        this.hidDevice.sendFeatureReport(featureReport);
+    }
+
+    _readResponse() {
+        return new Promise(resolve => {
+            resolve(this.hidDevice.getFeatureReport(REPORT_ID, REPORT_LENGTH));
+        });
+    }
+
+    // Helpers
+
+    _isValidCallback(callback) {
+        return (typeof callback === 'function');
+    }
+
+    _serverDown(on, delay) {
+        return new Promise(resolve => {
+            let dms = delay / 10;
+            this._sendCommand('D', on, dms >> 8, dms % 0xff);
+
+            setTimeout(resolve, delay);
+        });
+    }
+
+    _play(play, position) {
+        return new Promise(resolve => {
+            this._sendCommand('p', play, position);
+            resolve();
+        });
+    }
+
+    _playLoop({
+        play,
+        start,
+        end,
+        count
+    }) {
+        return new Promise(resolve => {
+            this._sendCommand('p', play, start, end, count);
+            resolve();
+        });
+    }
+
+    // Validators
+
+    _validateNumber(number, name, min, max) {
+        if (typeof number !== 'number') {
+            throw new Error(name + ' must be a number');
+        }
+
+        if (number < min || number > max) {
+            throw new Error(name + ' must be between ' + min + ' and ' + max);
+        }
+    }
+
+    _validateAddress(address) {
+        this._validateNumber(address, 'address', 0, 0xffff); // Decimal 0 - 65535
+    }
+
+    _validateValue(value) {
+        this._validateNumber(value, 'value', 0, 0xff); // Decimal 0 - 255
+    }
+
+    _validateCount(value) {
+        this._validateNumber(value, 'count', 0, 0xff); // Decimal 0 - 255
+    }
+
+    _validateFadeMillis(fadeMillis) {
+        this._validateNumber(fadeMillis, 'fadeMillis', 0, 0x9FFF6); // Decimal 0 - 655350
+    }
+
+    _validateRGB(r, g, b) {
+        this._validateNumber(r, 'r', 0, 0xff); // Decimal 0 - 255
+        this._validateNumber(g, 'g', 0, 0xff); // Decimal 0 - 255
+        this._validateNumber(b, 'b', 0, 0xff); // Decimal 0 - 255
+    }
+
+    _validateMillis(millis) {
+        this._validateNumber(millis, 'millis', 0, 0x9FFF6); // Decimal 0 - 655350
+    }
+
+    _validatePosition(position) {
+        this._validateNumber(position, 'position', 0, 11);
+    }
+
+    _validateIndex(index) {
+        this._validateNumber(index, 'index', 0, 2);
+    }
+
+    // API
+
+    version() {
+        return new Promise(resolve => {
+            this._sendCommand('v');
+
+            this._readResponse().then(response => {
+                resolve(String.fromCharCode(response[3]) + '.' + String.fromCharCode(response[4]));
+            });
+        });
+    }
+
+    eeRead(address) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validateAddress(address);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._sendCommand('e', address);
+
+            this._readResponse().then(response => {
+                resolve(response[3]);
+            });
+        });
+    }
+
+    eeWrite(address, value) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validateAddress(address);
+                this._validateValue(value);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._sendCommand('E', address, value);
+
+            this._readResponse().then(() => {
+                resolve();
+            });
+        });
+    }
+
+    degamma(n) {
+        // Allow pass-through r,g,b values
+        if (!this.doDegamma) {
+            return n;
+        }
+
+        return Math.floor(
+            ((1 << Math.floor(n / 32)) - 1) +
+            Math.floor(
+                (1 << Math.floor(n / 32)) * Math.floor((n % 32) + 1) + 15
+            ) / 32);
+    }
+
+    fadeToRGB({
+        delay,
+        red,
+        green,
+        blue,
+        index = 0
+    }) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validateFadeMillis(delay);
+                this._validateRGB(red, green, blue);
+                this._validateIndex(index);
+            } catch(error) {
+                reject(JSON.stringify({
+                    error,
+                    delay,
+                    red,
+                    green,
+                    blue,
+                    index
+                }));
+            }
+
+            let dms = delay / 10;
+            this._sendCommand('c', this.degamma(red), this.degamma(green), this.degamma(blue), dms >> 8, dms % 0xff, index);
+
+            setTimeout(() => resolve({
+                red,
+                green,
+                blue,
+                index
+            }), delay);
+        });
+    }
+
+    setRGB({
+        red,
+        green,
+        blue
+    }) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validateRGB(red, green, blue);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._sendCommand('n', this.degamma(red), this.degamma(green), this.degamma(blue));
+            resolve({
+                red,
+                green,
+                blue
+            });
+        });
+    }
+
+    off() {
+        return new Promise(resolve => {
+            this.setRGB({
+                red   : 0,
+                green : 0,
+                blue  : 0
+            }).then(response => {
+                resolve(response);
+            });
+        });
+    }
+
+    getRGB(index = 0) {
+        return new Promise(resolve => {
+            this._sendCommand('r', index, 0, 0, 0, 0, index);
+
+            this._readResponse().then(response => {
+                var red   = response[2];
+                var green = response[3];
+                var blue  = response[4];
+
+                resolve({
+                    red,
+                    green,
+                    blue
+                });
+            });
+        });
+    }
+
+    enableServerDown(delay) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validateMillis(delay);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._serverDown(1, delay).then(response => {
+                resolve();
+            });
+        });
+    }
+
+    disableServerDown(delay) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validateMillis(delay);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._serverDown(0, delay).then(response => {
+                resolve();
+            });
+        });
+    }
+
+    play(position) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validatePosition(position);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._play(1, position).then(response => {
+                resolve();
+            });
+        });
+    }
+
+    playLoop({
+        start,
+        end,
+        count
+    }) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validatePosition(start);
+                this._validatePosition(end);
+                this._validateCount(count);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._playLoop(1, start, end, count).then(() => {
+                resolve();
+            }).catch(error => {
+                reject(error);
+            });
+        });
+    }
+
+    pause() {
+        return new Promise(resolve => {
+            this._play(0, 0).then(() => {
+                resolve();
+            });
+        });
+    }
+
+    writePatternLine({
+        delay,
+        red,
+        green,
+        blue,
+        position
+    }) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validateFadeMillis(delay);
+                this._validateRGB(red, green, blue);
+                this._validatePosition(position);
+            } catch(error) {
+                reject(error);
+            }
+
+            let dms = delay / 10;
+            this._sendCommand('P', this.degamma(red), this.degamma(green), this.degamma(blue), dms >> 8, dms % 0xff, position, 0);
+            resolve();
+        });
+    }
+
+    readPatternLine(position) {
+        return new Promise((resolve, reject) => {
+            try {
+                this._validatePosition(position);
+            } catch(error) {
+                reject(error);
+            }
+
+            this._sendCommand('R', 0, 0, 0, 0, 0, position, 0);
+
+            this._readResponse().then(response => {
+                resolve({
+                    red   : response[2],
+                    green : response[3],
+                    blue  : response[4],
+                    delay : ((response[5] << 8) + (response[6] & 0xff)) * 10
+                });
+            });
+        });
+    }
+
+    close() {
+        return new Promise(resolve => {
+            this.hidDevice.close();
+            resolve();
+        });
+    }
 }
 
-Blink1.prototype._sendCommand = function(/* command [, args ...]*/) {
-  var featureReport = [REPORT_ID, 0, 0, 0, 0, 0, 0, 0, 0];
-
-  featureReport[1] = arguments[0].charCodeAt(0);
-
-  for (var i = 1; i < arguments.length; i++) {
-    featureReport[i + 1] = arguments[i];
-  }
-
-  this.hidDevice.sendFeatureReport(featureReport);
-};
-
-Blink1.prototype._isValidCallback = function(callback) {
-  return (typeof callback === 'function');
-};
-
-Blink1.prototype._validateNumber = function(number, name, min, max) {
-  if (typeof number !== 'number') {
-    throw new Error(name + ' must be a number');
-  }
-
-  if (number < min || number > max) {
-    throw new Error(name + ' must be between ' + min + ' and ' + max);
-  }
-};
-
-Blink1.prototype._validateAddress = function(address) {
-  this._validateNumber(address, 'address', 0, 0xffff);
-};
-
-Blink1.prototype._validateValue = function(value) {
-  this._validateNumber(value, 'value', 0, 0xff);
-};
-
-Blink1.prototype._validateCount = function(value) {
-  this._validateNumber(value, 'count', 0, 0xff);
-};
-
-Blink1.prototype._validateFadeMillis = function(fadeMillis) {
-  this._validateNumber(fadeMillis, 'fadeMillis', 0, 0x9FFF6);
-};
-
-Blink1.prototype._validateRGB = function(r, g, b) {
-  this._validateNumber(r, 'r', 0, 0xff);
-  this._validateNumber(g, 'g', 0, 0xff);
-  this._validateNumber(b, 'b', 0, 0xff);
-};
-
-Blink1.prototype._validateMillis = function(millis) {
-  this._validateNumber(millis, 'millis', 0, 0x9FFF6);
-};
-
-Blink1.prototype._validatePosition = function(position) {
-  this._validateNumber(position, 'position', 0, 11);
-};
-
-Blink1.prototype._validateIndex = function(index) {
-  this._validateNumber(index, 'index', 0, 2);
-};
-
-Blink1.prototype._readResponse = function(callback) {
-  if (this._isValidCallback(callback)) {
-    callback.apply(this, [this.hidDevice.getFeatureReport(REPORT_ID, REPORT_LENGTH)]);
-  }
-};
-
-Blink1.prototype.version = function(callback) {
-  this._sendCommand('v');
-
-  this._readResponse(function(response) {
-    var version = String.fromCharCode(response[3]) + '.' + String.fromCharCode(response[4]);
-
-    if(this._isValidCallback(callback)) {
-      callback(version);
-    }
-  });
-};
-
-Blink1.prototype.eeRead = function(address, callback) {
-  this._validateAddress(address);
-
-  this._sendCommand('e', address);
-
-  this._readResponse(function(response) {
-    var value = response[3];
-
-    if(this._isValidCallback(callback)) {
-      callback(value);
-    }
-  });
-};
-
-Blink1.prototype.eeWrite = function(address, value, callback) {
-  this._validateAddress(address);
-  this._validateValue(value);
-
-  this._sendCommand('E', address, value);
-
-  if(this._isValidCallback(callback)) {
-    callback();
-  }
-};
-
-Blink1.prototype.degamma = function(n) {
-  return Math.floor(((1 << Math.floor(n / 32)) - 1) +
-          Math.floor((1 << Math.floor(n / 32)) * Math.floor((n % 32) + 1) + 15) / 32);
-};
-
-
-Blink1.prototype.fadeToRGB = function(fadeMillis, r, g, b, index, callback) {
-  this._validateFadeMillis(fadeMillis);
-  this._validateRGB(r, g, b);
-
-  var dms = fadeMillis / 10;
-
-  if (this._isValidCallback(index)) {
-    // backwards compatible API, no index
-    callback = index;
-    index = 0;
-  } else if (index === undefined) {
-    index = 0;
-  }
-
-  this._validateIndex(index);
-
-  this._sendCommand('c', this.degamma(r), this.degamma(g), this.degamma(b), dms >> 8, dms % 0xff, index);
-
-  if(this._isValidCallback(callback)) {
-    setTimeout(callback, fadeMillis);
-  }
-};
-
-Blink1.prototype.setRGB = function(r, g, b, callback) {
-  this._validateRGB(r, g, b);
-
-  this._sendCommand('n', this.degamma(r), this.degamma(g), this.degamma(b));
-
-  if(this._isValidCallback(callback)) {
-    callback();
-  }
-};
-
-
-Blink1.prototype.off = function(callback) {
-  this.setRGB(0, 0, 0, callback);
-};
-
-Blink1.prototype.rgb = function(index, callback) {
-  if (this._isValidCallback(index)) {
-    callback = index;
-    index = 0;
-  } else if (index === undefined) {
-    index = 0;
-  }
-
-  this._sendCommand('r', index, 0, 0, 0, 0, index);
-
-  this._readResponse(function(response) {
-    var r = response[2];
-    var g = response[3];
-    var b = response[4];
-
-    if(this._isValidCallback(callback)) {
-      callback(r, g, b);
-    }
-  });
-};
-
-Blink1.prototype._serverDown = function(on, millis, callback) {
-  var dms = millis / 10;
-
-  this._sendCommand('D', on, dms >> 8, dms % 0xff);
-
-  if(this._isValidCallback(callback)) {
-    setTimeout(callback, millis);
-  }
-};
-
-Blink1.prototype.enableServerDown = function(millis, callback) {
-  this._validateMillis(millis);
-
-  this._serverDown(1, millis, callback);
-};
-
-Blink1.prototype.disableServerDown = function(millis, callback) {
-  this._validateMillis(millis);
-
-  this._serverDown(0, millis, callback);
-};
-
-Blink1.prototype._play = function(play, position, callback) {
-  this._sendCommand('p', play, position);
-
-  if(this._isValidCallback(callback)) {
-    callback();
-  }
-};
-
-Blink1.prototype.play = function(position, callback) {
-  this._validatePosition(position);
-
-  this._play(1, position, callback);
-};
-
-Blink1.prototype._playLoop = function(play, position, endPosition, count, callback) {
-  this._sendCommand('p', play, position, endPosition, count);
-
-  if(this._isValidCallback(callback)) {
-    callback();
-  }
-};
-
-Blink1.prototype.playLoop = function(startPosition, endPosition, count, callback) {
-  this._validatePosition(startPosition);
-  this._validatePosition(endPosition);
-  this._validateCount(count);
-
-  this._playLoop(1, startPosition, endPosition, count, callback);
-};
-
-Blink1.prototype.pause = function(callback) {
-  this._play(0, 0, callback);
-};
-
-Blink1.prototype.writePatternLine = function(fadeMillis, r, g, b, position, callback) {
-  this._validateFadeMillis(fadeMillis);
-  this._validateRGB(r, g, b);
-  this._validatePosition(position);
-
-  var dms = fadeMillis / 10;
-
-  this._sendCommand('P', this.degamma(r), this.degamma(g), this.degamma(b), dms >> 8, dms % 0xff, position, 0);
-
-  if(this._isValidCallback(callback)) {
-    callback();
-  }
-};
-
-Blink1.prototype.readPatternLine = function(position, callback) {
-  this._validatePosition(position);
-
-  this._sendCommand('R', 0, 0, 0, 0, 0, position, 0);
-
-  this._readResponse(function(response) {
-    var value = {
-      r: response[2],
-      g: response[3],
-      b: response[4],
-      fadeMillis: ((response[5] << 8) + (response[6] & 0xff)) * 10
-    };
-
-    if(this._isValidCallback(callback)) {
-      callback(value);
-    }
-  });
-};
-
-Blink1.prototype.close = function(callback) {
-	this.hidDevice.close();
-
-  if(this._isValidCallback(callback)) {
-    callback();
-  }
-};
-
-Blink1.devices = devices;
-
 module.exports = Blink1;
-module.exports.Blink1 = Blink1; // backwards compatibility with older version
-
+module.exports.Blink1  = Blink1; // backwards compatibility with older version
+module.exports.devices = devices;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "blink1"
   ],
   "dependencies": {
+    "lodash": "^4.17.4",
     "node-hid": "~0.5.0"
   },
   "devDependencies": {

--- a/unit-tests.js
+++ b/unit-tests.js
@@ -2,7 +2,7 @@
 var should = require('should');
 var mockery = require('mockery');
 
-describe('blink(1)', function() {
+describe('blink(1)', () => {
   var BLINK1_SRC_PATH = './blink1';
 
   var VENDOR_ID = 0x27B8;
@@ -78,24 +78,24 @@ describe('blink(1)', function() {
     sentFeatureReport = null;
   });
 
-  describe('#devices', function() {
+  describe('#devices', () => {
 
-    it('should return no serial numbers when there are no blink(1) HID devices', function() {
+    it('should return no serial numbers when there are no blink(1) HID devices', () => {
       mockHIDdevices = [];
 
       Blink1.devices().should.have.length(0);
     });
 
-    it('should return two serial numbers when there are two blink(1) HID devices', function() {
+    it('should return two serial numbers when there are two blink(1) HID devices', () => {
       mockHIDdevices = [MOCK_HID_DEVICE_1, MOCK_HID_DEVICE_2];
 
       Blink1.devices().should.eql([MOCK_HID_DEVICE_1_SERIAL_NUMBER, MOCK_HID_DEVICE_2_SERIAL_NUMBER]);
     });
   });
 
-  describe('#Blink1', function() {
+  describe('#Blink1', () => {
 
-    it('should throw an error when there are no blink(1) HID devices', function() {
+    it('should reject (catch) promise when there are no blink(1) HID devices', () => {
       mockHIDdevices = [];
 
       (function(){
@@ -103,13 +103,13 @@ describe('blink(1)', function() {
       }).should.throwError('No blink(1)\'s could be found');
     });
 
-    it('should not throw an error when there are blink(1) HID devices', function() {
+    it('should not throw an error when there are blink(1) HID devices', () => {
       mockHIDdevices = [MOCK_HID_DEVICE_1];
 
       new Blink1();
     });
 
-    it('should throw an error when there are no blink(1) HID devices with the supplied serial number', function() {
+    it('should reject (catch) promise when there are no blink(1) HID devices with the supplied serial number', () => {
       mockHIDdevices = [MOCK_HID_DEVICE_1];
 
       (function(){
@@ -117,27 +117,27 @@ describe('blink(1)', function() {
       }).should.throwError('No blink(1)\'s with serial number ' + MOCK_HID_DEVICE_2_SERIAL_NUMBER + ' could be found');
     });
 
-    it('should not throw an error when there are blink(1) HID devices with the supplied serial number', function() {
+    it('should not throw an error when there are blink(1) HID devices with the supplied serial number', () => {
       mockHIDdevices = [MOCK_HID_DEVICE_1];
 
       new Blink1(MOCK_HID_DEVICE_1_SERIAL_NUMBER);
     });
 
-    it('should store correct serial number', function() {
+    it('should store correct serial number', () => {
       mockHIDdevices = [MOCK_HID_DEVICE_1];
 
       var blink1 = new Blink1(MOCK_HID_DEVICE_1_SERIAL_NUMBER);
       blink1.serialNumber.should.eql(MOCK_HID_DEVICE_1_SERIAL_NUMBER);
     });
 
-    it('should select first blink(1) HID device when no serial number is supplied', function() {
+    it('should select first blink(1) HID device when no serial number is supplied', () => {
       mockHIDdevices = [MOCK_HID_DEVICE_1, MOCK_HID_DEVICE_2];
 
       var blink1 = new Blink1();
       blink1.serialNumber.should.eql(MOCK_HID_DEVICE_1_SERIAL_NUMBER);
     });
 
-    it('should open correct HID device path', function() {
+    it('should open correct HID device path', () => {
       mockHIDdevices = [MOCK_HID_DEVICE_1, MOCK_HID_DEVICE_2];
 
       var blink1 = new Blink1(MOCK_HID_DEVICE_1_SERIAL_NUMBER);
@@ -158,7 +158,7 @@ describe('blink(1)', function() {
     blink1 = null;
   };
 
-  describe('#Blink1.version', function() {
+  describe('#Blink1.version', () => {
 
     beforeEach(function() {
       setupBlink1();
@@ -167,28 +167,28 @@ describe('blink(1)', function() {
     });
     afterEach(teardownBlink1);
 
-    it('should send version feature report', function() {
+    it('should send version feature report', () => {
       blink1.version();
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x76, 0, 0, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back with version', function(done) {
-      blink1.version(function(version) {
+    it('should resolve promise with version', (done) => {
+      blink1.version().then(version => {
         done();
       });
     });
 
-    it('should call back with correct version', function(done) {
+    it('should resolve promise with correct version', (done) => {
 
-      blink1.version(function(version) {
+      blink1.version().then(version => {
         version.should.eql('1.0');
         done();
       });
     });
   });
 
-  describe('#Blink1.eeRead', function() {
+  describe('#Blink1.eeRead', () => {
 
     var ADDRESS = 1;
     var VALUE = 5;
@@ -200,46 +200,52 @@ describe('blink(1)', function() {
     });
     afterEach(teardownBlink1);
 
-    it('should throw an error when address is not a number', function() {
+    it('should reject (catch) promise when address is not a number', () => {
       (function(){
-        blink1.eeRead('Bad address');
-      }).should.throwError('address must be a number');
+        blink1.eeRead('Bad address').catch((error) => {
+            error.should.eql("Bad address must be a number")
+        });
+      })
     });
 
-    it('should throw an error when address is less than 0', function() {
+    it('should reject (catch) promise when address is less than 0', () => {
       (function(){
-        blink1.eeRead(-1);
-      }).should.throwError('address must be between 0 and 65535');
+        blink1.eeRead(-1).catch((error) => {
+            error.should.eql("address must be between 0 and 65535")
+        });
+      })
     });
 
-    it('should throw an error when address is greater than 65535', function() {
+    it('should reject (catch) promise when address is greater than 65535', () => {
       (function(){
-        blink1.eeRead(65536);
-      }).should.throwError('address must be between 0 and 65535');
+        blink1.eeRead(65536).catch((error) => {
+            error.should.eql("address must be between 0 and 65535")
+        });
+      })
     });
 
-    it('should send eeread feature report', function() {
+    it('should send eeread feature report', () => {
       blink1.eeRead(ADDRESS);
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x65, 1, 0, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back with value', function(done) {
-      blink1.eeRead(ADDRESS, function(value) {
+    it('should resolve promise with value', (done) => {
+      blink1.eeRead(ADDRESS).then(value => {
         done();
       });
     });
 
-    it('should call back with correct value', function(done) {
+    it('should resolve promise with correct value', (done) => {
 
-      blink1.eeRead(ADDRESS, function(value) {
+      blink1.eeRead(ADDRESS).then(value => {
         value.should.eql(VALUE);
         done();
       });
     });
   });
 
-  describe('#Blink1.eeWrite', function() {
+  describe('#Blink1.eeWrite', () => {
 
     var ADDRESS = 1;
     var VALUE = 5;
@@ -247,54 +253,68 @@ describe('blink(1)', function() {
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should throw an error when address is not a number', function() {
+    it('should reject (catch) promise when address is not a number', () => {
       (function(){
-        blink1.eeWrite('Bad address', VALUE);
-      }).should.throwError('address must be a number');
+        blink1.eeWrite('Bad address', VALUE).catch(error => {
+            error.should.eql("bad address must be a number");
+        });
+      })
     });
 
-    it('should throw an error when address is less than 0', function() {
+    it('should reject (catch) promise when address is less than 0', () => {
       (function(){
-        blink1.eeWrite(-1, VALUE);
-      }).should.throwError('address must be between 0 and 65535');
+        blink1.eeWrite(-1, VALUE).catch(error => {
+            error.should.eql("address must be between 0 and 65535");
+        });
+      })
     });
 
-    it('should throw an error when address is greater than 65535', function() {
+    it('should reject (catch) promise when address is greater than 65535', () => {
       (function(){
-        blink1.eeWrite(65536, VALUE);
-      }).should.throwError('address must be between 0 and 65535');
+        blink1.eeWrite(65536, VALUE).catch(error => {
+            error.should.eql("address must be between 0 and 65535");
+        });
+      })
     });
 
-    it('should throw an error when value is not a number', function() {
+    it('should reject (catch) promise when value is not a number', () => {
       (function(){
-        blink1.eeWrite(ADDRESS, 'Bad value');
-      }).should.throwError('value must be a number');
+        blink1.eeWrite(ADDRESS, 'Bad value').catch(error => {
+            error.should.eql("Bad value must be a number");
+        });
+      })
     });
 
-    it('should throw an error when value is less than 0', function() {
+    it('should reject (catch) promise when value is less than 0', () => {
       (function(){
-        blink1.eeWrite(ADDRESS, -1);
-      }).should.throwError('value must be between 0 and 255');
+        blink1.eeWrite(ADDRESS, -1).catch(error => {
+            error.should.eql("value must be between 0 and 255");
+        });
+      })
     });
 
-    it('should throw an error when value is greater than 255', function() {
+    it('should reject (catch) promise when value is greater than 255', () => {
       (function(){
-        blink1.eeWrite(ADDRESS, 256);
-      }).should.throwError('value must be between 0 and 255');
+        blink1.eeWrite(ADDRESS, 256).catch(error => {
+            error.should.eql("value must be between 0 and 255");
+        });
+      })
     });
 
-    it('should send eewrite feature report', function() {
+    it('should send eewrite feature report', () => {
       blink1.eeWrite(ADDRESS, VALUE);
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x45, ADDRESS, VALUE, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.eeWrite(ADDRESS, VALUE, done);
+    it('should resolve promise', (done) => {
+      blink1.eeWrite(ADDRESS, VALUE).then(() => {
+          done();
+      });
     });
   });
 
-  describe('#Blink1.fadeToRGB', function() {
+  describe('#Blink1.fadeToRGB', () => {
     var FADE_MILLIS = 10;
     var R = 10;
     var G = 20;
@@ -304,112 +324,238 @@ describe('blink(1)', function() {
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should throw an error when fadeMillis is not a number', function() {
+    it('should reject (catch) promise when fadeMillis is not a number', () => {
       (function(){
-        blink1.fadeToRGB('Bad fadeMillis', R, G, B);
-      }).should.throwError('fadeMillis must be a number');
+        blink1.fadeToRGB({
+            delay : 'Bad fadeMillis',
+            red   : R,
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("fadeMillis must be a number");
+        });
+      });
     });
 
-    it('should throw an error when fadeMillis is less than 0', function() {
+    it('should reject (catch) promise when fadeMillis is less than 0', () => {
       (function(){
-        blink1.fadeToRGB(-1, R, G, B);
-      }).should.throwError('fadeMillis must be between 0 and 655350');
+        blink1.fadeToRGB({
+            delay : -1,
+            red   : R,
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("fadeMillis must be between 0 and 655350");
+        });
+      });
     });
 
-    it('should throw an error when fadeMillis is greater than 655350', function() {
+    it('should reject (catch) promise when fadeMillis is greater than 655350', () => {
       (function(){
-        blink1.fadeToRGB(655351, R, G, B);
-      }).should.throwError('fadeMillis must be between 0 and 655350');
+        blink1.fadeToRGB({
+            delay : 655351,
+            red   : R,
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("fadeMillis must be between 0 and 655350");
+        });
+      });
     });
 
-    it('should throw an error when r is not a number', function() {
+    it('should reject (catch) promise when r is not a number', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, 'Bad r', G, B);
-      }).should.throwError('r must be a number');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : 'Bad r',
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("r must be a number");
+        });
+      });
     });
 
-    it('should throw an error when r is less than 0', function() {
+    it('should reject (catch) promise when r is less than 0', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, -1, G, B);
-      }).should.throwError('r must be between 0 and 255');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : -1,
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("r must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when r is greater than 255', function() {
+    it('should reject (catch) promise when r is greater than 255', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, 256, G, B);
-      }).should.throwError('r must be between 0 and 255');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : 256,
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("r must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when g is not a number', function() {
+    it('should reject (catch) promise when g is not a number', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, 'Bad g', B);
-      }).should.throwError('g must be a number');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : 'Bad g',
+            blue  : B
+        }).catch(error => {
+            error.should.eql("g must be a number");
+        });
+      });
     });
 
-    it('should throw an error when g is less than 0', function() {
+    it('should reject (catch) promise when g is less than 0', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, -1, B);
-      }).should.throwError('g must be between 0 and 255');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : -1,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("g must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when g is greater than 255', function() {
+    it('should reject (catch) promise when g is greater than 255', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, 256, B);
-      }).should.throwError('g must be between 0 and 255');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : 256,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("g must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when b is not a number', function() {
+    it('should reject (catch) promise when b is not a number', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, G, 'Bad b');
-      }).should.throwError('b must be a number');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : G,
+            blue  : 'Bad b'
+        }).catch(error => {
+            error.should.eql("b must be a number");
+        });
+      });
     });
 
-    it('should throw an error when b is less than 0', function() {
+    it('should reject (catch) promise when b is less than 0', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, G, -1);
-      }).should.throwError('b must be between 0 and 255');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : G,
+            blue  : -1
+        }).catch(error => {
+            error.should.eql("b must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when b is greater than 255', function() {
+    it('should reject (catch) promise when b is greater than 255', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, G, 256);
-      }).should.throwError('b must be between 0 and 255');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : G,
+            blue  : 256
+        }).catch(error => {
+            error.should.eql("b must be between 0 and 255");
+        });
+      });
     });
 
-    it('should send fadetorgb feature report', function() {
-      blink1.fadeToRGB(FADE_MILLIS, R, G, B);
+    it('should send fadetorgb feature report', () => {
+      blink1.fadeToRGB({
+          delay : FADE_MILLIS,
+          red   : R,
+          green : G,
+          blue  : B
+      });
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x63, blink1.degamma(R),  blink1.degamma(G),  blink1.degamma(B), (FADE_MILLIS / 10) >> 8, (FADE_MILLIS / 10) % 0xff, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.fadeToRGB(FADE_MILLIS, blink1.degamma(R),  blink1.degamma(G),  blink1.degamma(B), done);
+    it('should resolve promise', (done) => {
+      blink1.fadeToRGB({
+          delay : FADE_MILLIS,
+          red   : R,
+          green : G,
+          blue  : B
+      }).then(() => {
+          done();
+      });
     });
 
-    it('should throw an error when index is less than 0', function() {
+    it('should reject (catch) promise when index is less than 0', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, G, B, -1);
-      }).should.throwError('index must be between 0 and 2');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : G,
+            blue  : B,
+            index : -1
+        }).catch(error => {
+            error.should.eql("index must be between 0 and 2");
+        });
+      });
     });
 
-    it('should throw an error when index is greater than 2', function() {
+    it('should reject (catch) promise when index is greater than 2', () => {
       (function(){
-        blink1.fadeToRGB(FADE_MILLIS, R, G, B, 3);
-      }).should.throwError('index must be between 0 and 2');
+        blink1.fadeToRGB({
+            delay : FADE_MILLIS,
+            red   : R,
+            green : G,
+            blue  : B,
+            index : 3
+        }).catch(error => {
+            error.should.eql("index must be between 0 and 2");
+        });
+      });
     });
 
-    it('should send fadetorgb index feature report', function() {
-      blink1.fadeToRGB(FADE_MILLIS, R, G, B, INDEX);
+    it('should send fadetorgb index feature report', () => {
+      blink1.fadeToRGB({
+          delay : FADE_MILLIS,
+          red   : R,
+          green : G,
+          blue  : B,
+          index : INDEX
+      });
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x63, blink1.degamma(R),  blink1.degamma(G),  blink1.degamma(B), (FADE_MILLIS / 10) >> 8, (FADE_MILLIS / 10) % 0xff, INDEX, 0]);
     });
 
-    it('should call back (index)', function(done) {
-      blink1.fadeToRGB(FADE_MILLIS, blink1.degamma(R),  blink1.degamma(G),  blink1.degamma(B), INDEX, done);
+    it('should resolve promise (index)', (done) => {
+      blink1.fadeToRGB({
+          delay : FADE_MILLIS,
+          red   : R,
+          green : G,
+          blue  : B,
+          index : INDEX
+      }).then(() => {
+          done();
+      });
     });
   });
 
-  describe('#Blink1.setRGB', function() {
+  describe('#Blink1.setRGB', () => {
     var R = 10;
     var G = 20;
     var B = 40;
@@ -417,88 +563,154 @@ describe('blink(1)', function() {
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should throw an error when r is not a number', function() {
+    it('should reject (catch) promise when r is not a number', () => {
       (function(){
-        blink1.setRGB('Bad r', G, B);
-      }).should.throwError('r must be a number');
+        blink1.setRGB({
+            red   : 'Bad r',
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("r must be a number");
+        });
+      });
     });
 
-    it('should throw an error when r is less than 0', function() {
+    it('should reject (catch) promise when r is less than 0', () => {
       (function(){
-        blink1.setRGB(-1, G, B);
-      }).should.throwError('r must be between 0 and 255');
+        blink1.setRGB({
+            red   : -1,
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("r must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when r is greater than 255', function() {
+    it('should reject (catch) promise when r is greater than 255', () => {
       (function(){
-        blink1.setRGB(256, G, B);
-      }).should.throwError('r must be between 0 and 255');
+        blink1.setRGB({
+            red   : 256,
+            green : G,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("r must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when g is not a number', function() {
+    it('should reject (catch) promise when g is not a number', () => {
       (function(){
-        blink1.setRGB(R, 'Bad g', B);
-      }).should.throwError('g must be a number');
+        blink1.setRGB({
+            red   : R,
+            green : 'Bad g',
+            blue  : B
+        }).catch(error => {
+            error.should.eql("g must be a number");
+        });
+      });
     });
 
-    it('should throw an error when g is less than 0', function() {
+    it('should reject (catch) promise when g is less than 0', () => {
       (function(){
-        blink1.setRGB(R, -1, B);
-      }).should.throwError('g must be between 0 and 255');
+        blink1.setRGB({
+            red   : R,
+            green : -1,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("g must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when g is greater than 255', function() {
+    it('should reject (catch) promise when g is greater than 255', () => {
       (function(){
-        blink1.setRGB(R, 256, B);
-      }).should.throwError('g must be between 0 and 255');
+        blink1.setRGB({
+            red   : R,
+            green : 256,
+            blue  : B
+        }).catch(error => {
+            error.should.eql("g must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when b is not a number', function() {
+    it('should reject (catch) promise when b is not a number', () => {
       (function(){
-        blink1.setRGB(R, G, 'Bad b');
-      }).should.throwError('b must be a number');
+        blink1.setRGB({
+            red   : R,
+            green : G,
+            blue  : 'Bad b'
+        }).catch(error => {
+            error.should.eql("b must be a number");
+        });
+      });
     });
 
-    it('should throw an error when b is less than 0', function() {
+    it('should reject (catch) promise when b is less than 0', () => {
       (function(){
-        blink1.setRGB(R, G, -1);
-      }).should.throwError('b must be between 0 and 255');
+        blink1.setRGB({
+            red   : R,
+            green : G,
+            blue  : -1
+        }).catch(error => {
+            error.should.eql("b must be between 0 and 255");
+        });
+      });
     });
 
-    it('should throw an error when b is greater than 255', function() {
+    it('should reject (catch) promise when b is greater than 255', () => {
       (function(){
-        blink1.setRGB(R, G, 256);
-      }).should.throwError('b must be between 0 and 255');
+        blink1.setRGB({
+            red   : R,
+            green : G,
+            blue  : 256
+        }).catch(error => {
+            error.should.eql("b must be between 0 and 255");
+        });
+      });
     });
 
-    it('should send setrgb feature report', function() {
-      blink1.setRGB(R, G, B);
+    it('should send setrgb feature report', () => {
+      blink1.setRGB({
+          red   : R,
+          green : G,
+          blue  : B
+      });
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x6e, blink1.degamma(R),  blink1.degamma(G),  blink1.degamma(B), 0, 0, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.setRGB(R, G, B, done);
+    it('should resolve promise', (done) => {
+      blink1.setRGB({
+          red   : R,
+          green : G,
+          blue  : B
+      }).then(() => {
+          done();
+      });
     });
   });
 
-  describe('#Blink1.off', function() {
+  describe('#Blink1.off', () => {
 
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should send setrgb 0, 0, 0 feature report', function() {
+    it('should send setrgb 0, 0, 0 feature report', () => {
       blink1.off();
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x6e, 0, 0, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.off(done);
+    it('should resolve promise', (done) => {
+      blink1.off().then(() => {
+          done();
+      });
     });
   });
 
-  describe('#Blink1.rgb', function() {
+  describe('#Blink1.getRGB', () => {
     var INDEX = 1;
     var R = 1;
     var G = 2;
@@ -511,156 +723,180 @@ describe('blink(1)', function() {
     });
     afterEach(teardownBlink1);
 
-    it('should send rgb feature report', function() {
-      blink1.rgb();
+    it('should send rgb feature report', () => {
+      blink1.getRGB();
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x72, 0, 0, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back with r, g, b', function(done) {
-      blink1.rgb(function(r, g, b) {
+    it('should resolve promise with r, g, b', (done) => {
+      blink1.getRGB().then(({red, green, blue}) => {
         done();
       });
     });
 
-    it('should call back with correct r, g, b', function(done) {
-      blink1.rgb(function(r, g, b) {
-        r.should.eql(R);
-        g.should.eql(G);
-        b.should.eql(B);
+    it('should resolve promise with correct r, g, b', (done) => {
+      blink1.getRGB().then(({red, green, blue}) => {
+          red.should.eql(R);
+          green.should.eql(G);
+          blue.should.eql(B);
         done();
       });
     });
 
-    it('should send rgb index feature report', function() {
-      blink1.rgb(INDEX);
+    it('should send rgb index feature report', () => {
+      blink1.getRGB(INDEX);
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x72, INDEX, 0, 0, 0, 0, INDEX, 0]);
     });
 
-    it('should call back with r, g, b (index)', function(done) {
-      blink1.rgb(INDEX, function(r, g, b) {
+    it('should resolve promise with r, g, b (index)', (done) => {
+      blink1.getRGB(INDEX).then(({red, green, blue}) => {
         done();
       });
     });
 
-    it('should call back with correct r, g, b (index)', function(done) {
-      blink1.rgb(INDEX, function(r, g, b) {
-        r.should.eql(R);
-        g.should.eql(G);
-        b.should.eql(B);
+    it('should resolve promise with correct r, g, b (index)', (done) => {
+      blink1.getRGB(INDEX).then(({red, green, blue}) => {
+          red.should.eql(R);
+          green.should.eql(G);
+          blue.should.eql(B);
         done();
       });
     });
   });
 
-  describe('#Blink1.enableServerDown', function() {
+  describe('#Blink1.enableServerDown', () => {
     var MILLIS = 10;
 
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should throw an error when millis is not a number', function() {
+    it('should reject (catch) promise when millis is not a number', () => {
       (function(){
-        blink1.enableServerDown('Bad millis');
-      }).should.throwError('millis must be a number');
+        blink1.enableServerDown('Bad millis').catch(error => {
+          error.should.eql("millis must be a number");
+        });
+      });
     });
 
-    it('should throw an error when millis is less than 0', function() {
+    it('should reject (catch) promise when millis is less than 0', () => {
       (function(){
-        blink1.enableServerDown(-1);
-      }).should.throwError('millis must be between 0 and 655350');
+        blink1.enableServerDown(-1).catch(error => {
+          error.should.eql("millis must be between 0 and 655350");
+        });
+      });
     });
 
-    it('should throw an error when millis is greater than 655350', function() {
+    it('should reject (catch) promise when millis is greater than 655350', () => {
       (function(){
-        blink1.enableServerDown(655351);
-      }).should.throwError('millis must be between 0 and 655350');
+        blink1.enableServerDown(655351).catch(error => {
+          error.should.eql("millis must be between 0 and 655350");
+        });
+      });
     });
 
-    it('should send serverdown on feature report', function() {
+    it('should send serverdown on feature report', () => {
       blink1.enableServerDown(MILLIS);
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x44, 1, (MILLIS / 10) >> 8, (MILLIS / 10) % 0xff, 0, 0, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.enableServerDown(0, done);
+    it('should resolve promise', (done) => {
+      blink1.enableServerDown(0).then(() => {
+          done();
+      });
     });
   });
 
-  describe('#Blink1.disableServerDown', function() {
+  describe('#Blink1.disableServerDown', () => {
     var MILLIS = 10;
 
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should throw an error when millis is not a number', function() {
+    it('should reject (catch) promise when millis is not a number', () => {
       (function(){
-        blink1.disableServerDown('Bad millis');
-      }).should.throwError('millis must be a number');
+        blink1.disableServerDown('Bad millis').catch(error => {
+          error.should.eql("millis must be a number");
+        });
+      });
     });
 
-    it('should throw an error when millis is less than 0', function() {
+    it('should reject (catch) promise when millis is less than 0', () => {
       (function(){
-        blink1.disableServerDown(-1);
-      }).should.throwError('millis must be between 0 and 655350');
+        blink1.disableServerDown(-1).catch(error => {
+          error.should.eql("millis must be between 0 and 655350");
+        });
+      });
     });
 
-    it('should throw an error when millis is greater than 655350', function() {
+    it('should reject (catch) promise when millis is greater than 655350', () => {
       (function(){
-        blink1.disableServerDown(655351);
-      }).should.throwError('millis must be between 0 and 655350');
+        blink1.disableServerDown(-1).catch(error => {
+          error.should.eql("millis must be between 0 and 655350");
+        });
+      });
     });
 
-    it('should send serverdown off feature report', function() {
+    it('should send serverdown off feature report', () => {
       blink1.disableServerDown(0);
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x44, 0, 0, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.disableServerDown(0, done);
+    it('should resolve promise', (done) => {
+      blink1.disableServerDown(0).then(() => {
+        done();
+      });
     });
   });
 
-  describe('#Blink1.play', function() {
+  describe('#Blink1.play', () => {
     var POSITION = 5;
 
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
 
-    it('should throw an error when position is not a number', function() {
+    it('should reject (catch) promise when position is not a number', () => {
       (function(){
-        blink1.play('Bad position');
-      }).should.throwError('position must be a number');
+        blink1.play('Bad position').catch(error => {
+            error.should.eql('position must be a number');
+        });
+      });
     });
 
-    it('should throw an error when position is less than 0', function() {
+    it('should reject (catch) promise when position is less than 0', () => {
       (function(){
-        blink1.play(-1);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.play(-1).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should throw an error when position is greater than 11', function() {
+    it('should reject (catch) promise when position is greater than 11', () => {
       (function(){
-        blink1.play(12);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.play(12).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should send play on feature report', function() {
+    it('should send play on feature report', () => {
       blink1.play(POSITION);
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x70, 1, POSITION, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.play(0, done);
+    it('should resolve promise', (done) => {
+      blink1.play(0).then(() => {
+        done();
+      });
     });
   });
 
-  describe('#Blink1.playLoop', function() {
+  describe('#Blink1.playLoop', () => {
     var STARTPOSITION = 5;
     var ENDPOSITION = 8;
     var COUNT = 1;
@@ -669,81 +905,143 @@ describe('blink(1)', function() {
     afterEach(teardownBlink1);
 
 
-    it('should throw an error when start position is not a number', function() {
+    it('should reject (catch) promise when start position is not a number', () => {
       (function(){
-        blink1.playLoop('Bad position', 2, 2);
-      }).should.throwError('position must be a number');
+        blink1.playLoop({
+            start : 'Bad position',
+            end   : 2,
+            count : 2
+        }).catch(error => {
+            error.should.eql('position must be a number');
+        });
+      });
     });
 
-    it('should throw an error when end position is not a number', function() {
+    it('should reject (catch) promise when end position is not a number', () => {
       (function(){
-        blink1.playLoop(1, 'Bad position', 2);
-      }).should.throwError('position must be a number');
+        blink1.playLoop({
+            start : 1,
+            end   : 'Bad position',
+            count : 2
+        }).catch(error => {
+            error.should.eql('position must be a number');
+        });
+      });
     });
 
-    it('should throw an error when count is not a number', function() {
+    it('should reject (catch) promise when count is not a number', () => {
       (function(){
-        blink1.playLoop(1, 2, 'Bad count');
-      }).should.throwError('count must be a number');
+        blink1.playLoop({
+            start : 1,
+            end   : 2,
+            count : 'Bad count'
+        }).catch(error => {
+            error.should.eql('count must be a number');
+        });
+      });
     });
 
-    it('should throw an error when start position is less than 0', function() {
+    it('should reject (catch) promise when start position is less than 0', () => {
       (function(){
-        blink1.playLoop(-1, 2, 2);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.playLoop({
+            start : -1,
+            end   : 2,
+            count : 2
+        }).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should throw an error when end position is less than 0', function() {
+    it('should reject (catch) promise when end position is less than 0', () => {
       (function(){
-        blink1.playLoop(1, -1, 2);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.playLoop({
+            start : 1,
+            end   : -1,
+            count : 2
+        }).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should throw an error when count is less than 0', function() {
+    it('should reject (catch) promise when count is less than 0', () => {
       (function(){
-        blink1.playLoop(1, 1, -1);
-      }).should.throwError('count must be between 0 and 255');
+        blink1.playLoop({
+            start : 1,
+            end   : 1,
+            count : -1
+        }).catch(error => {
+            error.should.eql('count must be between 0 and 255');
+        });
+      });
     });
 
-    it('should throw an error when start position is greater than 11', function() {
+    it('should reject (catch) promise when start position is greater than 11', () => {
       (function(){
-        blink1.playLoop(12, 2, 2);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.playLoop({
+            start : 12,
+            end   : 2,
+            count : 2
+        }).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should throw an error when end position is greater than 11', function() {
+    it('should reject (catch) promise when end position is greater than 11', () => {
       (function(){
-        blink1.playLoop(2, 12, 2);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.playLoop({
+            start : 2,
+            end   : 12,
+            count : 2
+        }).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should send play on feature report', function() {
-      blink1.playLoop(STARTPOSITION, ENDPOSITION, COUNT );
+    it('should send play on feature report', () => {
+      (function(){
+        blink1.playLoop({
+          start : STARTPOSITION,
+          end   : ENDPOSITION,
+          count : COUNT
+        });
 
-      sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x70, 1, STARTPOSITION, ENDPOSITION, COUNT, 0, 0, 0]);
+        sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x70, 1, STARTPOSITION, ENDPOSITION, COUNT, 0, 0, 0]);
+      });
     });
 
-    it('should call back', function(done) {
-      blink1.playLoop(0, 1, 1, done);
+    it('should resolve promise', (done) => {
+      blink1.playLoop({
+          start : 0,
+          end   : 1,
+          count : 1
+      }).then(() => {
+          done();
+      });
     });
   });
 
-  describe('#Blink1.pause', function() {
+  describe('#Blink1.pause', () => {
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should send play off feature report', function() {
+    it('should send play off feature report', () => {
       blink1.pause();
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x70, 0, 0, 0, 0, 0, 0, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.pause(done);
+    it('should resolve promise', (done) => {
+      blink1.pause().then(() => {
+        done();
+      });
     });
   });
 
-  describe('#Blink1.writePatternLine', function() {
+  describe('#Blink1.writePatternLine', () => {
     var FADE_MILLIS = 10;
     var R = 10;
     var G = 20;
@@ -753,108 +1051,242 @@ describe('blink(1)', function() {
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should throw an error when fadeMillis is not a number', function() {
+    it('should reject (catch) promise when fadeMillis is not a number', () => {
       (function(){
-        blink1.writePatternLine('Bad fadeMillis', R, G, B, POSITION);
-      }).should.throwError('fadeMillis must be a number');
+        blink1.writePatternLine({
+            delay    : 'Bad fadeMillis',
+            red      : R,
+            green    : G,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('fadeMillis must be a number');
+        });
+      });
     });
 
-    it('should throw an error when fadeMillis is less than 0', function() {
+    it('should reject (catch) promise when fadeMillis is less than 0', () => {
       (function(){
-        blink1.writePatternLine(-1, R, G, B, POSITION);
-      }).should.throwError('fadeMillis must be between 0 and 655350');
+        blink1.writePatternLine({
+            delay    : -1,
+            red      : R,
+            green    : G,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('fadeMillis must be between 0 and 655350');
+        });
+      });
     });
 
-    it('should throw an error when fadeMillis is greater than 655350', function() {
+    it('should reject (catch) promise when fadeMillis is greater than 655350', () => {
       (function(){
-        blink1.writePatternLine(655351, R, G, B, POSITION);
-      }).should.throwError('fadeMillis must be between 0 and 655350');
+        blink1.writePatternLine({
+            delay    : 655351,
+            red      : R,
+            green    : G,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('fadeMillis must be between 0 and 655350');
+        });
+      });
     });
 
-    it('should throw an error when r is not a number', function() {
+    it('should reject (catch) promise when r is not a number', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, 'Bad r', G, B, POSITION);
-      }).should.throwError('r must be a number');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : 'Bad r',
+            green    : G,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('r must be a number');
+        });
+      });
     });
 
-    it('should throw an error when r is less than 0', function() {
+    it('should reject (catch) promise when r is less than 0', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, -1, G, B, POSITION);
-      }).should.throwError('r must be between 0 and 255');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : -1,
+            green    : G,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('r must be between 0 and 255');
+        });
+      });
     });
 
-    it('should throw an error when r is greater than 255', function() {
+    it('should reject (catch) promise when r is greater than 255', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, 256, G, B, POSITION);
-      }).should.throwError('r must be between 0 and 255');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : 256,
+            green    : G,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('r must be between 0 and 255');
+        });
+      });
     });
 
-    it('should throw an error when g is not a number', function() {
+    it('should reject (catch) promise when g is not a number', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, 'Bad g', B, POSITION);
-      }).should.throwError('g must be a number');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : 'Bad g',
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('g must be a number');
+        });
+      });
     });
 
-    it('should throw an error when g is less than 0', function() {
+    it('should reject (catch) promise when g is less than 0', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, -1, B, POSITION);
-      }).should.throwError('g must be between 0 and 255');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : -1,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('g must be between 0 and 255');
+        });
+      });
     });
 
-    it('should throw an error when g is greater than 255', function() {
+    it('should reject (catch) promise when g is greater than 255', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, 256, B, POSITION);
-      }).should.throwError('g must be between 0 and 255');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : 256,
+            blue     : B,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('g must be between 0 and 255');
+        });
+      });
     });
 
-    it('should throw an error when b is not a number', function() {
+    it('should reject (catch) promise when b is not a number', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, G, 'Bad b', POSITION);
-      }).should.throwError('b must be a number');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : G,
+            blue     : 'Bad b',
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('b must be a number');
+        });
+      });
     });
 
-    it('should throw an error when b is less than 0', function() {
+    it('should reject (catch) promise when b is less than 0', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, G, -1, POSITION);
-      }).should.throwError('b must be between 0 and 255');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : G,
+            blue     : -1,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('b must be between 0 and 255');
+        });
+      });
     });
 
-    it('should throw an error when b is greater than 255', function() {
+    it('should reject (catch) promise when b is greater than 255', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, G, 256, POSITION);
-      }).should.throwError('b must be between 0 and 255');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : G,
+            blue     : 256,
+            position : POSITION
+        }).catch(error => {
+            error.should.eql('b must be between 0 and 255');
+        });
+      });
     });
 
-    it('should throw an error when position is not a number', function() {
+    it('should reject (catch) promise when position is not a number', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, G, B, 'Bad position');
-      }).should.throwError('position must be a number');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : G,
+            blue     : B,
+            position : 'Bad position'
+        }).catch(error => {
+            error.should.eql('position must be a number');
+        });
+      });
     });
 
-    it('should throw an error when position is less than 0', function() {
+    it('should reject (catch) promise when position is less than 0', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, G, B, -1);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : G,
+            blue     : B,
+            position : -1
+        }).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should throw an error when position is greater than 11', function() {
+    it('should reject (catch) promise when position is greater than 11', () => {
       (function(){
-        blink1.writePatternLine(FADE_MILLIS, R, G, B, 12);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.writePatternLine({
+            delay    : FADE_MILLIS,
+            red      : R,
+            green    : G,
+            blue     : B,
+            position : 12
+        }).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should send writepatternline feature report', function() {
-      blink1.writePatternLine(FADE_MILLIS, R, G, B, POSITION);
+    it('should send writepatternline feature report', () => {
+      blink1.writePatternLine({
+          delay    : FADE_MILLIS,
+          red      : R,
+          green    : G,
+          blue     : B,
+          position : POSITION
+      });
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x50, blink1.degamma(R),  blink1.degamma(G),  blink1.degamma(B), (FADE_MILLIS / 10) >> 8, (FADE_MILLIS / 10) % 0xff, POSITION, 0]);
     });
 
-    it('should call back', function(done) {
-      blink1.writePatternLine(FADE_MILLIS, R, G, B, POSITION, done);
+    it('should resolve promise', (done) => {
+      blink1.writePatternLine({
+          delay    : FADE_MILLIS,
+          red      : R,
+          green    : G,
+          blue     : B,
+          position : POSITION
+      }).then(() => {
+          done();
+      });
     });
   });
 
-  describe('#Blink1.readPatternLine', function() {
+  describe('#Blink1.readPatternLine', () => {
     var POSITION = 5;
 
     var FADE_MILLIS = 1000;
@@ -869,61 +1301,79 @@ describe('blink(1)', function() {
     });
     afterEach(teardownBlink1);
 
-    it('should throw an error when position is not a number', function() {
+    it('should reject (catch) promise when position is not a number', () => {
       (function(){
-        blink1.readPatternLine('Bad position');
-      }).should.throwError('position must be a number');
+        blink1.readPatternLine('Bad position').catch(error => {
+            error.should.eql('position must be a number');
+        });
+      });
     });
 
-    it('should throw an error when position is less than 0', function() {
+    it('should reject (catch) promise when position is less than 0', () => {
       (function(){
-        blink1.readPatternLine(-1);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.readPatternLine(-1).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should throw an error when position is greater than 11', function() {
+    it('should reject (catch) promise when position is greater than 11', () => {
       (function(){
-        blink1.readPatternLine(12);
-      }).should.throwError('position must be between 0 and 11');
+        blink1.readPatternLine(12).catch(error => {
+            error.should.eql('position must be between 0 and 11');
+        });
+      });
     });
 
-    it('should send readpatternline feature report', function() {
+    it('should send readpatternline feature report', () => {
       blink1.readPatternLine(POSITION);
 
       sentFeatureReport.should.eql([FEATURE_REPORT_ID, 0x52, 0, 0, 0, 0, 0, POSITION, 0]);
     });
 
-    it('should call back with value', function(done) {
-      blink1.readPatternLine(POSITION, function(value) {
-        done();
+    it('should resolve promise with value', (done) => {
+      blink1.readPatternLine(POSITION).then(({
+          red,
+          green,
+          blue,
+          delay
+      }) => {
+          done();
       });
     });
 
-    it('should call back with correct value', function(done) {
+    it('should resolve promise with correct value', (done) => {
 
-      blink1.readPatternLine(POSITION, function(value) {
-        value.r.should.eql(R);
-        value.g.should.eql(G);
-        value.b.should.eql(B);
-        value.fadeMillis.should.eql(FADE_MILLIS);
+      blink1.readPatternLine(POSITION).then(({
+          red,
+          green,
+          blue,
+          delay
+      }) => {
+          red.should.eql(R);
+          green.should.eql(G);
+          blue.should.eql(B);
+          delay.should.eql(FADE_MILLIS);
 
-        done();
+          done();
       });
     });
   });
 
-  describe('#Blink1.close', function() {
+  describe('#Blink1.close', () => {
     beforeEach(setupBlink1);
     afterEach(teardownBlink1);
 
-    it('should close HID device', function(done) {
-      blink1.close(done);
+    it('should close HID device', (done) => {
+      blink1.close().then(() => {
+        done();
+      });
 
       closed.should.eql(true);
     });
 
-    it('should callback', function(done) {
-      blink1.close(function() {
+    it('should resolve promise', (done) => {
+      blink1.close().then(() => {
         closed.should.eql(true);
 
         done();


### PR DESCRIPTION
Now methods can be chained together.

This PR contains breaking changes. All `callback` logic has been removed and replaced with Promise logic.

Unit tests have been updated.